### PR TITLE
Fix Overview Page Spacing

### DIFF
--- a/components/preview/overview-page.tsx
+++ b/components/preview/overview-page.tsx
@@ -203,14 +203,14 @@ export function OverviewPage({ organizationId }: OverviewPageProps) {
         <div className="mb-6 sm:mb-8 grid gap-4 md:grid-cols-2">
           {/* Saved Messages Card */}
           <Card>
-            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+            <CardHeader>
               <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
                 <BookmarkIcon className="size-4" weight="fill" />
                 Saved Messages
               </CardTitle>
               <CardDescription className="text-xs sm:text-sm">Messages you've saved for later</CardDescription>
             </CardHeader>
-            <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
+            <CardContent>
               {savedMessages.length === 0 ? (
                 <div className="flex h-20 sm:h-24 items-center justify-center rounded-md border border-dashed border-[#26251E]/10">
                   <p className="text-xs sm:text-sm text-[#26251E]/40">No saved messages</p>
@@ -271,14 +271,14 @@ export function OverviewPage({ organizationId }: OverviewPageProps) {
 
           {/* Mentions Card */}
           <Card>
-            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+            <CardHeader>
               <CardTitle className="flex items-center gap-2 text-sm sm:text-base">
                 <AtIcon className="size-4" />
                 Mentions
               </CardTitle>
               <CardDescription className="text-xs sm:text-sm">Messages where you were mentioned</CardDescription>
             </CardHeader>
-            <CardContent className="p-4 sm:p-6 pt-0 sm:pt-0">
+            <CardContent>
               {mentions.length === 0 ? (
                 <div className="flex h-20 sm:h-24 items-center justify-center rounded-md border border-dashed border-[#26251E]/10">
                   <p className="text-xs sm:text-sm text-[#26251E]/40">No mentions</p>


### PR DESCRIPTION
## Summary
Adjusted spacing for Saved Messages and Mentions sections in Overview page by removing explicit padding classes and relying on default Card component styling. 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/18fa4662-4475-4293-8582-7882a37a1df7) [![linear.app](https://internal.tembo.io/static/view/linear.svg?v=4)](https://linear.app/tryportal/issue/POR-23/fix-spacing) [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Simplified spacing for Saved Messages and Mentions cards by removing explicit padding overrides and relying on Card component defaults.

- Removed custom padding classes (`p-4 sm:p-6 pb-3 sm:pb-4`) from CardHeader components
- Removed custom padding classes (`p-4 sm:p-6 pt-0 sm:pt-0`) from CardContent components  
- Cards now use default Card component styling: horizontal padding (`px-4`) from CardHeader/CardContent, vertical padding (`py-4`) and gap spacing (`gap-4`) from the parent Card container
- This change removes responsive padding variations (sm:p-6) and creates consistent spacing across both cards

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change simplifies styling by removing explicit padding overrides and relying on the Card component's default spacing system, which is a safe refactor that improves consistency and maintainability without changing functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| components/preview/overview-page.tsx | Removed explicit padding classes from CardHeader and CardContent, relying on default Card component styling for consistent spacing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OverviewPage
    participant Card
    participant CardHeader
    participant CardContent

    User->>OverviewPage: Views Overview Page
    OverviewPage->>Card: Render Saved Messages Card
    Card->>Card: Apply py-4 (vertical) + gap-4 (between children)
    Card->>CardHeader: Render with default px-4
    Note over CardHeader: Previously: p-4 sm:p-6 pb-3 sm:pb-4<br/>Now: Uses default px-4 only
    CardHeader-->>Card: Header rendered
    Card->>CardContent: Render with default px-4
    Note over CardContent: Previously: p-4 sm:p-6 pt-0 sm:pt-0<br/>Now: Uses default px-4 only
    CardContent-->>Card: Content rendered
    Card-->>OverviewPage: Card rendered with consistent spacing
    
    OverviewPage->>Card: Render Mentions Card
    Card->>Card: Apply py-4 (vertical) + gap-4 (between children)
    Card->>CardHeader: Render with default px-4
    CardHeader-->>Card: Header rendered
    Card->>CardContent: Render with default px-4
    CardContent-->>Card: Content rendered
    Card-->>OverviewPage: Card rendered with consistent spacing
    
    OverviewPage-->>User: Overview page displayed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->