### PR TITLE
feat: add baseUrl parameter to invitation system

### DIFF
--- a/components/invite-people-dialog.tsx
+++ b/components/invite-people-dialog.tsx
@@ -90,6 +90,7 @@ export function InvitePeopleDialog({
         organizationId,
         email: email.trim(),
         role,
+        baseUrl,
       });
       analytics.invitationSent({ method: "email", role });
       setSuccess(true);

--- a/components/setup/setup-wizard.tsx
+++ b/components/setup/setup-wizard.tsx
@@ -243,10 +243,12 @@ export function SetupWizard({ organizationId: initialOrgId }: SetupWizardProps) 
     if (!currentOrgId) {
       throw new Error("Please complete the first step first");
     }
+    const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
     await sendInvitation({
       organizationId: currentOrgId,
       email,
       role: role === "org:admin" ? "admin" : "member",
+      baseUrl,
     });
   };
 

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -10,6 +10,7 @@ export const sendInvitationEmail = action({
     organizationId: v.id("organizations"),
     email: v.string(),
     role: v.union(v.literal("admin"), v.literal("member")),
+    baseUrl: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ invitationId: string; token: string }> => {
     // First create the invitation in the database
@@ -34,8 +35,7 @@ export const sendInvitationEmail = action({
       return result;
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    const inviteUrl = `${baseUrl}/invite/${result.token}`;
+    const inviteUrl = `${args.baseUrl || "http://localhost:3000"}/invite/${result.token}`;
 
     // Send email using inbound.new API
     try {
@@ -59,9 +59,7 @@ export const sendInvitationEmail = action({
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #F7F7F4; padding: 40px 20px; margin: 0;">
   <div style="max-width: 480px; margin: 0 auto; background: white; border-radius: 12px; padding: 40px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
     <div style="text-align: center; margin-bottom: 32px;">
-      <div style="width: 48px; height: 48px; background: #26251E; border-radius: 10px; display: inline-flex; align-items: center; justify-content: center;">
-        <span style="color: white; font-weight: bold; font-size: 20px;">P</span>
-      </div>
+      <img src="${(args.baseUrl || "http://localhost:3000")}/portal.svg" alt="Portal" width="48" height="48" style="width: 48px; height: 48px;">
     </div>
     
     <h1 style="color: #26251E; font-size: 24px; font-weight: 600; margin: 0 0 16px; text-align: center;">


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors invitation system to use dynamic `baseUrl` parameter instead of server-side environment variable. Client components now pass `window.location.origin` to the invitation action, enabling correct URL generation across different deployment environments.

**Key changes:**
- `convex/invitations.ts`: Added optional `baseUrl` parameter to `sendInvitationEmail` action, uses it for building invite URLs and email logo paths instead of `NEXT_PUBLIC_APP_URL` env var
- `components/invite-people-dialog.tsx`: Passes client-computed `baseUrl` from `window.location.origin` with fallback to env var
- `components/setup/setup-wizard.tsx`: Passes `baseUrl` from `window.location.origin` with empty string fallback

**Issues found:**
- In `setup-wizard.tsx`, the fallback is an empty string which could result in malformed URLs like `/invite/token` if the action runs server-side. Should use `NEXT_PUBLIC_APP_URL` fallback like `invite-people-dialog.tsx` does.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor fix recommended
- The implementation is well-structured and solves the problem of dynamic URL generation across environments. However, the empty string fallback in setup-wizard.tsx could cause malformed invitation URLs if the code ever runs server-side, though this is unlikely given the action is triggered from client components
- Pay close attention to `components/setup/setup-wizard.tsx` - fix the empty string fallback to prevent potential URL issues

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| convex/invitations.ts | Changed from environment variable to parameter-based baseUrl for invitation emails, now uses client-provided URL or fallback to localhost |
| components/invite-people-dialog.tsx | Added baseUrl parameter to sendInvitation call, computed from window.location.origin with fallback to env var |
| components/setup/setup-wizard.tsx | Added baseUrl parameter to sendInvitation call during setup wizard, uses window.location.origin with empty string fallback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client (Browser)
    participant Dialog as InvitePeopleDialog/SetupWizard
    participant Action as sendInvitationEmail
    participant Mutation as inviteMember
    participant DB as Database
    participant API as Inbound.new API
    participant User as Invited User

    Client->>Dialog: User enters email
    Dialog->>Dialog: Get window.location.origin as baseUrl
    Dialog->>Action: sendInvitation({organizationId, email, role, baseUrl})
    Action->>Mutation: inviteMember({organizationId, email, role})
    Mutation->>DB: Create invitation record
    DB-->>Mutation: Return {invitationId, token}
    Mutation-->>Action: Return invitation data
    Action->>Action: Build inviteUrl using baseUrl parameter
    Action->>API: POST email with inviteUrl
    API-->>Action: Email sent confirmation
    Action-->>Dialog: Return {invitationId, token}
    Dialog-->>Client: Show success message
    API->>User: Send invitation email with inviteUrl
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->