### PR TITLE
Client message hover flicker

### DIFF
--- a/components/preview/message-styles.tsx
+++ b/components/preview/message-styles.tsx
@@ -550,6 +550,7 @@ function HoverActions({
   handleEditClick,
   handleCopy,
   setIsMenuOpen,
+  onHover,
   position = "right",
 }: {
   message: Message
@@ -566,6 +567,7 @@ function HoverActions({
   handleEditClick: () => void
   handleCopy: () => void
   setIsMenuOpen: (open: boolean) => void
+  onHover?: (messageId: string | null) => void
   position?: "left" | "right"
 }) {
   const handleSaveToggle = () => {
@@ -577,7 +579,11 @@ function HoverActions({
   }
 
   return (
-    <div className={`absolute -top-3 ${position === "left" ? "left-4" : "right-4"} flex items-center gap-0.5 rounded-lg border border-border bg-card p-0.5 shadow-md z-10`}>
+    <div 
+      className={`absolute -top-3 ${position === "left" ? "left-4" : "right-4"} flex items-center gap-0.5 rounded-lg border border-border bg-card p-0.5 shadow-md z-10`}
+      // Explicitly trigger hover when cursor enters the toolbar to cancel any pending hide
+      onMouseEnter={() => onHover?.(message.id)}
+    >
       <Button
         variant="ghost"
         size="icon-xs"
@@ -860,6 +866,7 @@ export function CompactMessageItem({
           handleEditClick={handleEditClick}
           handleCopy={handleCopy}
           setIsMenuOpen={setIsMenuOpen}
+          onHover={onHover}
           position="right"
         />
       )}
@@ -1070,6 +1077,7 @@ export function BubbleMessageItem({
           handleEditClick={handleEditClick}
           handleCopy={handleCopy}
           setIsMenuOpen={setIsMenuOpen}
+          onHover={onHover}
           position={isOwn ? "left" : "right"}
         />
       )}


### PR DESCRIPTION
Add a debounced hover handler to prevent UI flickering when moving the cursor between a message and its hover actions toolbar.

The flickering occurred because the hover actions toolbar is positioned slightly above the message. When the cursor moved from the message content towards the toolbar, it briefly left the message container's bounds, triggering `onMouseLeave` and hiding the toolbar. This rapid show/hide cycle caused the flickering. The debounce introduces a short delay before hiding the toolbar, allowing the cursor to enter the toolbar, which then explicitly re-triggers the hover state.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1391742-36c8-457e-81c2-7a8a12830855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1391742-36c8-457e-81c2-7a8a12830855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented a debounced hover handler to fix UI flickering when moving the cursor between message content and the hover actions toolbar. The flickering occurred because the toolbar is positioned above the message, causing the cursor to briefly exit the message bounds when moving toward it.

**Key Changes:**
- Added `hoverTimeoutRef` to track the debounce timeout
- Modified `handleMessageHover` to immediately show the toolbar on hover, but delay hiding by 100ms
- Added cleanup effect to prevent memory leaks on unmount
- Added `onMouseEnter` to the `HoverActions` toolbar to explicitly cancel pending hide timeouts

The solution is elegant and minimal, solving the UX issue without introducing complexity.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- The implementation is clean, correct, and focused. The debounce logic properly clears timeouts, includes cleanup on unmount, and the 100ms delay is a reasonable UX compromise. No edge cases or bugs identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| components/preview/message-list.tsx | Added debounced hover handler with 100ms delay to prevent flickering; includes proper cleanup on unmount |
| components/preview/message-styles.tsx | Added `onHover` prop to HoverActions component with `onMouseEnter` handler to cancel pending hide timeouts |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Message
    participant handleMessageHover
    participant Timeout
    participant Toolbar
    participant State

    Note over User,State: Hover Enter Flow
    User->>Message: Mouse enters message
    Message->>handleMessageHover: onHover(messageId)
    handleMessageHover->>Timeout: Clear any pending timeout
    handleMessageHover->>State: setHoveredMessageId(messageId)
    State->>Toolbar: Show toolbar (immediately)

    Note over User,State: Moving to Toolbar (No Flicker)
    User->>Message: Mouse leaves message
    Message->>handleMessageHover: onHover(null)
    handleMessageHover->>Timeout: Clear any pending timeout
    handleMessageHover->>Timeout: Start 100ms hide timeout
    Note over Timeout: Waiting 100ms...
    User->>Toolbar: Mouse enters toolbar (within 100ms)
    Toolbar->>handleMessageHover: onHover(messageId)
    handleMessageHover->>Timeout: Clear pending timeout (cancel hide)
    handleMessageHover->>State: setHoveredMessageId(messageId)
    Note over State: Toolbar remains visible

    Note over User,State: Hover Leave Flow
    User->>Toolbar: Mouse leaves toolbar
    Toolbar->>handleMessageHover: onHover(null)
    handleMessageHover->>Timeout: Start 100ms hide timeout
    Note over Timeout: Wait 100ms...
    Timeout->>State: setHoveredMessageId(null)
    State->>Toolbar: Hide toolbar

    Note over User,State: Cleanup on Unmount
    Message->>handleMessageHover: Component unmount
    handleMessageHover->>Timeout: Clear timeout
    Note over Timeout: Prevent memory leak
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->