### PR TITLE
leaving workspaces

### DIFF
--- a/app/w/[slug]/people/[userId]/page.tsx
+++ b/app/w/[slug]/people/[userId]/page.tsx
@@ -98,6 +98,9 @@ export default function MemberProfilePage({
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [leaveError, setLeaveError] = useState<string | null>(null);
 
   React.useEffect(() => {
     if (params instanceof Promise) {
@@ -113,6 +116,7 @@ export default function MemberProfilePage({
   const updateRole = useMutation(api.organizations.updateOrganizationMemberRole);
   const removeMember = useMutation(api.organizations.removeOrganizationMember);
   const updateProfile = useMutation(api.organizations.updateMemberProfile);
+  const leaveOrganization = useMutation(api.organizations.leaveOrganization);
 
   React.useEffect(() => {
     const fetchMember = async () => {
@@ -257,6 +261,25 @@ export default function MemberProfilePage({
       setRemoveDialogOpen(false);
     } finally {
       setIsRemoving(false);
+    }
+  };
+
+  const handleLeaveWorkspace = async () => {
+    if (!organization?._id) return;
+
+    setIsLeaving(true);
+    setLeaveError(null);
+
+    try {
+      await leaveOrganization({
+        organizationId: organization._id,
+      });
+
+      router.push("/");
+    } catch (err) {
+      setLeaveError(err instanceof Error ? err.message : "Failed to leave workspace");
+    } finally {
+      setIsLeaving(false);
     }
   };
 
@@ -568,6 +591,47 @@ export default function MemberProfilePage({
                               className="bg-red-600 hover:bg-red-700"
                             >
                               {isRemoving ? "Removing..." : "Remove"}
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    </div>
+                  )}
+
+                  {/* Leave Workspace - for own profile only */}
+                  {member && member.userId === currentUserId && (
+                    <div className="pt-4 border-t border-border space-y-4">
+                      <AlertDialog 
+                        open={leaveDialogOpen} 
+                        onOpenChange={(open) => {
+                          setLeaveDialogOpen(open);
+                          if (!open) setLeaveError(null);
+                        }}
+                      >
+                        <AlertDialogTrigger 
+                          render={<button className="text-xs text-red-600 hover:text-red-700 flex items-center gap-1" />}
+                        >
+                          <TrashIcon className="size-3" />
+                          Leave workspace
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Leave Workspace</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Are you sure you want to leave this workspace? You will lose access immediately and will need to be re-invited to rejoin.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          {leaveError && (
+                            <p className="text-sm text-red-600">{leaveError}</p>
+                          )}
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={handleLeaveWorkspace}
+                              disabled={isLeaving}
+                              className="bg-red-600 hover:bg-red-700"
+                            >
+                              {isLeaving ? "Leaving..." : "Leave"}
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added workspace leave functionality allowing members to remove themselves from workspaces. The implementation includes a new `leaveOrganization` mutation with proper validation to prevent the last admin from leaving, and UI components in both the people list page and individual profile page with confirmation dialogs and error handling.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor improvements recommended
- The implementation is solid with proper validation logic preventing edge cases (last admin cannot leave), consistent error handling, and appropriate UX patterns using confirmation dialogs. Minor deduction for missing analytics tracking which is used consistently for other user actions in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| convex/organizations.ts | Added `leaveOrganization` mutation with proper validation to prevent last admin from leaving |
| app/w/[slug]/people/page.tsx | Added Leave button in header with alert dialog, missing analytics tracking for leave action |
| app/w/[slug]/people/[userId]/page.tsx | Added leave workspace section to user profile page, missing analytics tracking for leave action |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as People Page/Profile Page
    participant Frontend as React Component
    participant Backend as leaveOrganization Mutation
    participant DB as Database

    User->>UI: Click "Leave" button
    UI->>Frontend: Open AlertDialog
    User->>Frontend: Confirm leave action
    Frontend->>Frontend: setIsLeaving(true)
    Frontend->>Backend: leaveOrganization({ organizationId })
    Backend->>Backend: Verify authentication
    Backend->>DB: Query organizationMembers by user
    DB-->>Backend: Return membership
    alt Not a member
        Backend-->>Frontend: Error: "Not a member"
        Frontend->>UI: Display error message
    else Is last admin
        Backend->>DB: Count admins in organization
        DB-->>Backend: Return admin count
        Backend-->>Frontend: Error: "Cannot leave as last admin"
        Frontend->>UI: Display error message
    else Valid leave
        Backend->>DB: Delete membership record
        DB-->>Backend: Success
        Backend-->>Frontend: { success: true }
        Frontend->>Frontend: router.push("/")
        Frontend->>UI: Redirect to home page
    end
    Frontend->>Frontend: setIsLeaving(false)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->