### PR TITLE
Always mark channel as read when viewing, regardless of message presence

### DIFF
--- a/app/w/[slug]/[category]/[channel]/page.tsx
+++ b/app/w/[slug]/[category]/[channel]/page.tsx
@@ -163,9 +163,9 @@ export default function ChannelPage({
   const forwardMessage = useMutation(api.messages.forwardMessage);
   const markChannelAsRead = useMutation(api.channels.markChannelAsRead);
 
-  // Mark channel as read when viewing, when new messages arrive, and when leaving
+  // Mark channel as read when viewing and when leaving
   React.useEffect(() => {
-    if (channelId && filteredMessages && filteredMessages.length > 0) {
+    if (channelId) {
       markChannelAsRead({ channelId }).catch(() => {
         // Ignore errors - user may not have access or channel may not exist
       });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR removes the conditional check for message presence when marking a channel as read, allowing channels to be marked read immediately upon viewing even if they contain no messages.

**Changes:**
- Removed the `filteredMessages && filteredMessages.length > 0` condition from the mark-as-read `useEffect`
- Updated inline comment to reflect that marking happens "when viewing and when leaving" instead of "when viewing, when new messages arrive, and when leaving"

**Impact:**
The backend `markChannelAsRead` mutation uses `Date.now()` to mark all messages up to the current time as read, making it safe to call regardless of whether messages exist. This change prevents edge cases where empty channels might not get their read status updated, which could affect UI state like unread indicators.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change removes an unnecessary condition that could cause bugs. The backend implementation uses timestamp-based marking that doesn't depend on message presence, so this simplification is both correct and improves reliability
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/w/[slug]/[category]/[channel]/page.tsx | Removed unnecessary message presence check from mark-as-read logic, allowing channels to be marked read immediately on viewing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChannelPage
    participant React
    participant Backend
    
    User->>ChannelPage: Navigate to channel
    ChannelPage->>React: useEffect triggered (channelId changes)
    React->>Backend: markChannelAsRead({ channelId })
    Backend->>Backend: Update lastReadAt to Date.now()
    Backend-->>React: Success (or ignore error)
    
    Note over ChannelPage: Channel marked as read<br/>immediately upon viewing<br/>(no message check needed)
    
    User->>ChannelPage: Navigate away
    ChannelPage->>React: useEffect cleanup runs
    React->>Backend: markChannelAsRead({ channelId })
    Backend->>Backend: Update lastReadAt to Date.now()
    Backend-->>React: Success (or ignore error)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->